### PR TITLE
Fix Markdown formatting issue

### DIFF
--- a/Anthropic 1P/05_Formatting_Output_and_Speaking_for_Claude.ipynb
+++ b/Anthropic 1P/05_Formatting_Output_and_Speaking_for_Claude.ipynb
@@ -95,7 +95,7 @@
    "source": [
     "Why is this something we'd want to do? Well, having the output in **XML tags allows the end user to reliably get the poem and only the poem by writing a short program to extract the content between XML tags**.\n",
     "\n",
-    "An extension of this technique is to **put the first XML tag in the `assistant` turn. When you put text in the `assistant` turn, you're basically telling Claude that Claude has already said something, and that it should continue from that point onward. This technique is called \"speaking for Claude\" or \"prefilling Claude's response.\"\n",
+    "An extension of this technique is to **put the first XML tag in the `assistant` turn.** When you put text in the `assistant` turn, you're basically telling Claude that Claude has already said something, and that it should continue from that point onward. This technique is called \"speaking for Claude\" or \"prefilling Claude's response.\"\n",
     "\n",
     "Below, we've done this with the first `<haiku>` XML tag. Notice how Claude continues directly from where we left off."
    ]


### PR DESCRIPTION
The bold sequence wasn't terminated, leaving a dangling "**" in the markdown. Fixed.