### PR TITLE
Fix typo: "handilgj" → "handling" in Tool Use appendix

### DIFF
--- a/AmazonBedrock/anthropic/10_2_Appendix_Tool_Use.ipynb
+++ b/AmazonBedrock/anthropic/10_2_Appendix_Tool_Use.ipynb
@@ -99,7 +99,7 @@
     "\n",
     "*This lesson teaches our current tool use format. However, we will be updating and improving tool use functionality in the near future, including:*\n",
     "* *A more streamlined format for function definitions and calls*\n",
-    "* *More robust error handilgj and edge case coverage*\n",
+    "* *More robust error handling and edge case coverage*\n",
     "* *Tighter integration with the rest of our API*\n",
     "* *Better reliability and performance, especially for more complex tool use tasks*"
    ]

--- a/AmazonBedrock/boto3/10_2_Appendix_Tool_Use.ipynb
+++ b/AmazonBedrock/boto3/10_2_Appendix_Tool_Use.ipynb
@@ -104,7 +104,7 @@
     "\n",
     "*This lesson teaches our current tool use format. However, we will be updating and improving tool use functionality in the near future, including:*\n",
     "* *A more streamlined format for function definitions and calls*\n",
-    "* *More robust error handilgj and edge case coverage*\n",
+    "* *More robust error handling and edge case coverage*\n",
     "* *Tighter integration with the rest of our API*\n",
     "* *Better reliability and performance, especially for more complex tool use tasks*"
    ]

--- a/Anthropic 1P/10.2_Appendix_Tool Use.ipynb
+++ b/Anthropic 1P/10.2_Appendix_Tool Use.ipynb
@@ -91,7 +91,7 @@
     "\n",
     "*This lesson teaches our current tool use format. However, we will be updating and improving tool use functionality in the near future, including:*\n",
     "* *A more streamlined format for function definitions and calls*\n",
-    "* *More robust error handilgj and edge case coverage*\n",
+    "* *More robust error handling and edge case coverage*\n",
     "* *Tighter integration with the rest of our API*\n",
     "* *Better reliability and performance, especially for more complex tool use tasks*"
    ]


### PR DESCRIPTION
Fixes #11

The typo appeared in all three variants of the 10.2 Appendix Tool Use notebook:
- Anthropic 1P/10.2_Appendix_Tool Use.ipynb
- AmazonBedrock/anthropic/10_2_Appendix_Tool_Use.ipynb
- AmazonBedrock/boto3/10_2_Appendix_Tool_Use.ipynb

🤖 Generated with [Claude Code](https://claude.com/claude-code)