### PR TITLE
Fix incorrect response description in Chapter 4 notebook

### DIFF
--- a/AmazonBedrock/anthropic/04_Separating_Data_and_Instructions.ipynb
+++ b/AmazonBedrock/anthropic/04_Separating_Data_and_Instructions.ipynb
@@ -139,9 +139,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "Here, **Claude thinks \"Yo Claude\" is part of the email it's supposed to rewrite**! You can tell because it begins its rewrite with \"Dear Claude\". To the human eye, it's clear, particularly in the prompt template where the email begins and ends, but it becomes much less clear in the prompt after substitution."
-   ]
+   "source": "Here, **Claude thinks \"Yo Claude\" is part of the email it's supposed to rewrite**! You can tell because it addresses \"Claude\" in its rewrite (e.g., \"Dear Claude\" or similar). To the human eye, it's clear, particularly in the prompt template where the email begins and ends, but it becomes much less clear in the prompt after substitution."
   },
   {
    "cell_type": "markdown",

--- a/AmazonBedrock/boto3/04_Separating_Data_and_Instructions.ipynb
+++ b/AmazonBedrock/boto3/04_Separating_Data_and_Instructions.ipynb
@@ -143,9 +143,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "Here, **Claude thinks \"Yo Claude\" is part of the email it's supposed to rewrite**! You can tell because it begins its rewrite with \"Dear Claude\". To the human eye, it's clear, particularly in the prompt template where the email begins and ends, but it becomes much less clear in the prompt after substitution."
-   ]
+   "source": "Here, **Claude thinks \"Yo Claude\" is part of the email it's supposed to rewrite**! You can tell because it addresses \"Claude\" in its rewrite (e.g., \"Dear Claude\" or similar). To the human eye, it's clear, particularly in the prompt template where the email begins and ends, but it becomes much less clear in the prompt after substitution."
   },
   {
    "cell_type": "markdown",

--- a/Anthropic 1P/04_Separating_Data_and_Instructions.ipynb
+++ b/Anthropic 1P/04_Separating_Data_and_Instructions.ipynb
@@ -133,9 +133,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "Here, **Claude thinks \"Yo Claude\" is part of the email it's supposed to rewrite**! You can tell because it begins its rewrite with \"Dear Claude\". To the human eye, it's clear, particularly in the prompt template where the email begins and ends, but it becomes much less clear in the prompt after substitution."
-   ]
+   "source": "Here, **Claude thinks \"Yo Claude\" is part of the email it's supposed to rewrite**! You can tell because it addresses \"Claude\" in its rewrite (e.g., \"Dear Claude\" or similar). To the human eye, it's clear, particularly in the prompt template where the email begins and ends, but it becomes much less clear in the prompt after substitution."
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
The description claimed Claude begins its rewrite with "Dear Claude" when demonstrating the data/instruction separation issue. Updated to more accurately describe that Claude addresses "Claude" in its rewrite (e.g., "Dear Claude" or similar), since actual output may vary.

Fixes #37