### PR TITLE
Fix broken getting-started links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,35 +5,38 @@
 This course is intended to provide you with a comprehensive step-by-step understanding of how to engineer optimal prompts within Claude.
 
 **After completing this course, you will be able to**:
-- Master the basic structure of a good prompt 
+
+- Master the basic structure of a good prompt
 - Recognize common failure modes and learn the '80/20' techniques to address them
 - Understand Claude's strengths and weaknesses
 - Build strong prompts from scratch for common use cases
 
 ## Course structure and content
 
-This course is structured to allow you many chances to practice writing and troubleshooting prompts yourself. The course is broken up into **9 chapters with accompanying exercises**, as well as an appendix of even more advanced methods. It is intended for you to **work through the course in chapter order**. 
+This course is structured to allow you many chances to practice writing and troubleshooting prompts yourself. The course is broken up into **9 chapters with accompanying exercises**, as well as an appendix of even more advanced methods. It is intended for you to **work through the course in chapter order**.
 
 **Each lesson has an "Example Playground" area** at the bottom where you are free to experiment with the examples in the lesson and see for yourself how changing prompts can change Claude's responses. There is also an [answer key](https://docs.google.com/spreadsheets/d/1jIxjzUWG-6xBVIa2ay6yDpLyeuOh_hR_ZB75a47KX_E/edit?usp=sharing).
 
 Note: This tutorial uses our smallest, fastest, and cheapest model, Claude 3 Haiku. Anthropic has [two other models](https://docs.anthropic.com/claude/docs/models-overview), Claude 3 Sonnet and Claude 3 Opus, which are more intelligent than Haiku, with Opus being the most intelligent.
 
-*This tutorial also exists on [Google Sheets using Anthropic's Claude for Sheets extension](https://docs.google.com/spreadsheets/d/19jzLgRruG9kjUQNKtCg1ZjdD6l6weA6qRXG5zLIAhC8/edit?usp=sharing). We recommend using that version as it is more user friendly.*
+_This tutorial also exists on [Google Sheets using Anthropic's Claude for Sheets extension](https://docs.google.com/spreadsheets/d/19jzLgRruG9kjUQNKtCg1ZjdD6l6weA6qRXG5zLIAhC8/edit?usp=sharing). We recommend using that version as it is more user friendly._
 
-When you are ready to begin, go to `01_Basic Prompt Structure` to proceed.
+When you are ready to begin, go to [`00_Tutorial_How-To`](Anthropic%201P/00_Tutorial_How-To.ipynb) to get set up. Then head to the first lesson, [`01_Basic_Prompt_Structure`](Anthropic%201P/01_Basic_Prompt_Structure.ipynb), to start learning!
 
 ## Table of Contents
 
 Each chapter consists of a lesson and a set of exercises.
 
 ### Beginner
+
 - **Chapter 1:** Basic Prompt Structure
 
-- **Chapter 2:** Being Clear and Direct  
+- **Chapter 2:** Being Clear and Direct
 
 - **Chapter 3:** Assigning Roles
 
-### Intermediate 
+### Intermediate
+
 - **Chapter 4:** Separating Data from Instructions
 
 - **Chapter 5:** Formatting Output & Speaking for Claude
@@ -43,6 +46,7 @@ Each chapter consists of a lesson and a set of exercises.
 - **Chapter 7:** Using Examples
 
 ### Advanced
+
 - **Chapter 8:** Avoiding Hallucinations
 
 - **Chapter 9:** Building Complex Prompts (Industry Use Cases)


### PR DESCRIPTION
## Summary

- The "When you are ready to begin" paragraph in the README had a plain-text reference (`01_Basic Prompt Structure`) with **no clickable link**, making it a dead end for new learners
- Added a working link to **`00_Tutorial_How-To`** so users can set up their environment first
- Fixed the **`01_Basic_Prompt_Structure`** reference to be a proper clickable link to the notebook
- Updated copy to guide learners through the correct sequence: setup → first lesson

## Before

> When you are ready to begin, go to `01_Basic Prompt Structure` to proceed.

## After

> When you are ready to begin, go to [`00_Tutorial_How-To`](Anthropic%201P/00_Tutorial_How-To.ipynb) to get set up. Then head to the first lesson, [`01_Basic_Prompt_Structure`](Anthropic%201P/01_Basic_Prompt_Structure.ipynb), to start learning!

## Test plan

- [ ] Verify both notebook links resolve correctly from the README on GitHub
- [ ] Confirm the `00_Tutorial_How-To.ipynb` path matches the actual file in `Anthropic 1P/`
- [ ] Confirm the `01_Basic_Prompt_Structure.ipynb` path matches the actual file in `Anthropic 1P/`