### PR TITLE
Fix compatibility: Update anthropic to 0.78.0 and pin httpx to 0.27.2

### DIFF
--- a/AmazonBedrock/requirements.txt
+++ b/AmazonBedrock/requirements.txt
@@ -1,5 +1,6 @@
 awscli==1.32.74
 boto3==1.34.74
 botocore==1.34.74
-anthropic==0.21.3
+anthropic==0.78.0
+httpx==0.27.2
 pickleshare==0.7.5


### PR DESCRIPTION
- Updates anthropic from 0.21.3 to 0.78.0
- Adds httpx==0.27.2 to fix 'proxies' parameter incompatibility
- Resolves TypeError when initializing AnthropicBedrock client