### PR TITLE
Fix response printing for Claude's output in Exercise 01

### DIFF
--- a/Anthropic 1P/01_Basic_Prompt_Structure.ipynb
+++ b/Anthropic 1P/01_Basic_Prompt_Structure.ipynb
@@ -146,7 +146,7 @@
     "    )\n",
     "\n",
     "# Print Claude's response\n",
-    "print(response[0].text)"
+    "print(response.content[0].text)"
    ]
   },
   {
@@ -174,7 +174,7 @@
     "    )\n",
     "\n",
     "# Print Claude's response\n",
-    "print(response[0].text)"
+    "print(response.content[0].text)"
    ]
   },
   {
@@ -408,7 +408,7 @@
     "    )\n",
     "\n",
     "# Print Claude's response\n",
-    "print(response[0].text)"
+    "print(response.content[0].text)"
    ]
   },
   {
@@ -429,7 +429,7 @@
     "    )\n",
     "\n",
     "# Print Claude's response\n",
-    "print(response[0].text)"
+    "print(response.content[0].text)"
    ]
   },
   {


### PR DESCRIPTION
- The Messages API returns a `Messages` object and we should get the `content` as done [here](https://github.com/anthropics/prompt-eng-interactive-tutorial/blob/master/Anthropic%201P/01_Basic_Prompt_Structure.ipynb?short_path=625c8e6#L46)
- Otherwise, if the user fixes the prompting error exemplified here, they will run into an error since the Message object is not subscriptable
<img width="1380" height="580" alt="Screenshot 2026-03-04 at 15 46 25" src="https://github.com/user-attachments/assets/a91deedf-9fde-4070-9d1d-71f36b026430" />
