### PR TITLE
Fix outdated response access syntax in Basic Prompt Structure notebooks

### DIFF
--- a/AmazonBedrock/anthropic/01_Basic_Prompt_Structure.ipynb
+++ b/AmazonBedrock/anthropic/01_Basic_Prompt_Structure.ipynb
@@ -159,7 +159,7 @@
     "    )\n",
     "\n",
     "# Print Claude's response\n",
-    "print(response[0].text)"
+    "print(response.content[0].text)"
    ]
   },
   {
@@ -194,7 +194,7 @@
     "    )\n",
     "\n",
     "# Print Claude's response\n",
-    "print(response[0].text)"
+    "print(response.content[0].text)"
    ]
   },
   {
@@ -428,7 +428,7 @@
     "    )\n",
     "\n",
     "# Print Claude's response\n",
-    "print(response[0].text)"
+    "print(response.content[0].text)"
    ]
   },
   {
@@ -449,7 +449,7 @@
     "    )\n",
     "\n",
     "# Print Claude's response\n",
-    "print(response[0].text)"
+    "print(response.content[0].text)"
    ]
   },
   {

--- a/AmazonBedrock/boto3/01_Basic_Prompt_Structure.ipynb
+++ b/AmazonBedrock/boto3/01_Basic_Prompt_Structure.ipynb
@@ -167,7 +167,7 @@
     "response = client.invoke_model(body=body, modelId=MODEL_NAME)\n",
     "\n",
     "# Print Claude's response\n",
-    "print(response[0].text)"
+    "print(response.content[0].text)"
    ]
   },
   {
@@ -208,7 +208,7 @@
     "response = client.invoke_model(body=body, modelId=MODEL_NAME)\n",
     "\n",
     "# Print Claude's response\n",
-    "print(response[0].text)"
+    "print(response.content[0].text)"
    ]
   },
   {
@@ -446,7 +446,7 @@
     "response = client.invoke_model(body=body, modelId=MODEL_NAME)\n",
     "\n",
     "# Print Claude's response\n",
-    "print(response[0].text)"
+    "print(response.content[0].text)"
    ]
   },
   {
@@ -473,7 +473,7 @@
     "response = client.invoke_model(body=body, modelId=MODEL_NAME)\n",
     "\n",
     "# Print Claude's response\n",
-    "print(response[0].text)"
+    "print(response.content[0].text)"
    ]
   },
   {

--- a/Anthropic 1P/01_Basic_Prompt_Structure.ipynb
+++ b/Anthropic 1P/01_Basic_Prompt_Structure.ipynb
@@ -146,7 +146,7 @@
     "    )\n",
     "\n",
     "# Print Claude's response\n",
-    "print(response[0].text)"
+    "print(response.content[0].text)"
    ]
   },
   {
@@ -174,7 +174,7 @@
     "    )\n",
     "\n",
     "# Print Claude's response\n",
-    "print(response[0].text)"
+    "print(response.content[0].text)"
    ]
   },
   {
@@ -408,7 +408,7 @@
     "    )\n",
     "\n",
     "# Print Claude's response\n",
-    "print(response[0].text)"
+    "print(response.content[0].text)"
    ]
   },
   {
@@ -429,7 +429,7 @@
     "    )\n",
     "\n",
     "# Print Claude's response\n",
-    "print(response[0].text)"
+    "print(response.content[0].text)"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Replace `response[0].text` with `response.content[0].text` in all three variants of `01_Basic_Prompt_Structure.ipynb`
- The old `response[0].text` syntax no longer works with the current Anthropic Python SDK — the correct way to access response text is `response.content[0].text`
- Affects: Anthropic 1P, AmazonBedrock/anthropic, and AmazonBedrock/boto3 notebooks (4 cells each, 12 total)

## Test plan
- [ ] Open each modified notebook and verify cells render correctly
- [ ] Run the intentionally-broken example cells (malformed messages) and confirm they still raise the expected API error
- [ ] Run the working example cells and confirm `response.content[0].text` returns Claude's response correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)